### PR TITLE
On 64-bit builds, avoid a compiler warning

### DIFF
--- a/Hungarian.cpp
+++ b/Hungarian.cpp
@@ -24,8 +24,8 @@ HungarianAlgorithm::~HungarianAlgorithm(){}
 //********************************************************//
 double HungarianAlgorithm::Solve(vector <vector<double> >& DistMatrix, vector<int>& Assignment)
 {
-	unsigned int nRows = DistMatrix.size();
-	unsigned int nCols = DistMatrix[0].size();
+	const unsigned int nRows = static_cast<unsigned int>(DistMatrix.size());
+	const unsigned int nCols = static_cast<unsigned int>(DistMatrix[0].size());
 
 	double *distMatrixIn = new double[nRows * nCols];
 	int *assignment = new int[nRows];


### PR DESCRIPTION
Problem: on 64-bit builds the Microsoft Visual C++ compiler issues warning:
`C4267: 'initializing' : conversion from 'size_t' to 'unsigned int', possible loss of data`

Solution: add an explicit typecast

Btw – thank you for having released this algorithm! Works great for me.
