### PR TITLE
Add minimal CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.5)
+project(hungarian CXX)
+
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard version to use (default is 11)")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(hungarian Hungarian.cpp)
+
+include(CTest)
+if(BUILD_TESTING)
+  add_executable(test_hungarian testMain.cpp)
+  target_link_libraries(test_hungarian PRIVATE hungarian)
+endif()


### PR DESCRIPTION
This is a basic build configuration for CMake that builds

- library, shared on static, depending on [BUILD_SHARED_LIBS=ON|OFF](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) option
- test, depending on [BUILD_TESTING=ON|OFF](https://cmake.org/cmake/help/v3.7/module/CTest.html) option