### PR TITLE
Replace std::cerr print-out with exception for error handling

### DIFF
--- a/Hungarian.cpp
+++ b/Hungarian.cpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <cfloat> // for DBL_MAX
 #include <cmath>  // for fabs()
+#include <stdexcept>
 #include "Hungarian.h"
 
 
@@ -76,7 +77,7 @@ void HungarianAlgorithm::assignmentoptimal(int *assignment, double *cost, double
 	{
 		value = distMatrixIn[row];
 		if (value < 0)
-			cerr << "All matrix elements have to be non-negative." << endl;
+			throw std::runtime_error("All matrix elements have to be non-negative");
 		distMatrix[row] = value;
 	}
 

--- a/Hungarian.h
+++ b/Hungarian.h
@@ -12,7 +12,6 @@
 #ifndef HUNGARIAN_H
 #define HUNGARIAN_H
 
-#include <iostream>
 #include <vector>
 
 using namespace std;


### PR DESCRIPTION
It is a good idea to avoid any output to stdout/stderr from a library.
The `std::cerr` seems to be used as error handling check, so I replaced it with `throw` of exception with the message.